### PR TITLE
Fix: maxCombo 기록 안되는 오류 수정

### DIFF
--- a/src/components/Game/GameHead/Timer.tsx
+++ b/src/components/Game/GameHead/Timer.tsx
@@ -21,11 +21,10 @@ function Timer() {
 
     if (gameMode === GAME_STATE.PROCEEDING) {
       startTimer();
-    } else if (gameMode === GAME_STATE.OVER) {
-      dispatch(checkLastCombo());
     }
     return () => {
       clearInterval(timerId);
+      dispatch(checkLastCombo());
     };
   }, [gameMode, dispatch]);
 


### PR DESCRIPTION
콤보가 한번도 초기화 된 채로 게임을 중단되거나 종료되면 콤보의 최고 기록이 기록 안되던 오류를 수정했습니다.